### PR TITLE
Add ImDrawCmd.UserCallback support

### DIFF
--- a/ImGuiScene/ImGui_Impl/Renderers/IImGuiRenderer.cs
+++ b/ImGuiScene/ImGui_Impl/Renderers/IImGuiRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ImGuiNET;
 
 namespace ImGuiScene
 {
@@ -7,10 +8,16 @@ namespace ImGuiScene
     /// </summary>
     public interface IImGuiRenderer
     {
+        public delegate void DrawCmdUserCallbackDelegate(ImDrawDataPtr drawData, ImDrawCmdPtr drawCmd);
+
+        public nint ResetDrawCmdUserCallback { get; }
+
         // FIXME - probably a better way to do this than params object[] !
         void Init(params object[] initParams);
         void Shutdown();
         void NewFrame();
         void RenderDrawData(ImGuiNET.ImDrawDataPtr drawData);
+        public nint AddDrawCmdUserCallback(DrawCmdUserCallbackDelegate @delegate);
+        public void RemoveDrawCmdUserCallback(DrawCmdUserCallbackDelegate @delegate);
     }
 }


### PR DESCRIPTION
Added to `IImGuiRenderer`:
* `ResetDrawCmdUserCallback`
* `AddDrawCmdUserCallback`
* `RemoveDrawCmdUserCallback`

Each `ImDrawList.AddCallback` will cause the current render parameters to be changed for the following operation. `ResetDrawCmdUserCallback` is provided to reset reset render parameters to the renderer defaults.

Example usage:
```cs
DeviceContext deviceContext = (valid_value);
RawDX11Scene scene = (valid_value);
PixelShader pixelShader = (valid_value);
SamplerState samplerState = (valid_value);
nint myCallback;

void Initialize() => myCallback = scene.Renderer.AddDrawCmdUserCallback(MyCallbackBody);

void Uninitialize() => scene.Renderer.RemoveDrawCmdUserCallback(MyCallbackBody);

void MyCallbackBody(ImDrawDataPtr drawData, ImDrawCmdPtr drawCmd) {
    deviceContext.PixelShader.Set(pixelShader);
    deviceContext.PixelShader.SetSampler(0, samplerState);
}

void Draw() {
    ImGui.AddCallback(myCallback, nint.Zero);
    ImGui.Image(someImage, new(1024, 1024));
    ImGui.AddCallback(scene.Renderer.ResetDrawCmdUserCallback, nint.Zero);
}
```