### PR TITLE
Reduce the number of times GetForegroundWindow() is called per frame

### DIFF
--- a/ImGuiScene/ImGui_Impl/Input/ImGui_Input_Impl_Direct.cs
+++ b/ImGuiScene/ImGui_Impl/Input/ImGui_Input_Impl_Direct.cs
@@ -459,15 +459,15 @@ namespace ImGuiScene
             var io = ImGui.GetIO();
             if (!io.WantTextInput)
             {
-                for (int i = (int)ImGuiKey.NamedKey_BEGIN; i < (int)ImGuiKey.NamedKey_END; i++) {
-                    // Skip raising modifier keys if the game is focused.
+                var isForegroundWindow = User32.GetForegroundWindow() == _hWnd;
+                for (var key = ImGuiKey.NamedKey_BEGIN; key < ImGuiKey.NamedKey_END; key++) {
+                    // Skip releasing modifier keys if the game is focused.
                     // This allows us to raise the keys when one is held and the window becomes unfocused,
                     // but if we do not skip them, they will only be held down every 4th frame or so.
-                    if (User32.GetForegroundWindow() == this._hWnd &&
-                        (IsGamepadKey((ImGuiKey) i) ||
-                        IsModKey((ImGuiKey) i)))
+                    if (isForegroundWindow && (IsGamepadKey(key) || IsModKey(key)))
                         continue;
-                    io.AddKeyEvent((ImGuiKey) i, false);
+                    if (ImGui.IsKeyDown(key))
+                        io.AddKeyEvent(key, false);
                 }
             }
         }


### PR DESCRIPTION
`GetForegroundWindow` from `winuser.h` is a surprisingly expensive function, so I modified `ProcessKeyEventsWorkarounds` to call this function once per frame instead of around 140 times per frame. This change alone reduces title screen non-wait CPU time of FFXIV by a little over 1% on my PC.

I also added an `IsKeyDown` check before sending the key release event. This was harder to benchmark but should be faster in almost every case since `AddKeyEvent` also checks the key state internally in addition to doing a lot of other things, and keys will be mostly up.