### PR TITLE
Clear reused PixelShader texture pointer after draw

### DIFF
--- a/ImGuiScene/ImGui_Impl/Renderers/ImGui_Impl_DX11.cs
+++ b/ImGuiScene/ImGui_Impl/Renderers/ImGui_Impl_DX11.cs
@@ -443,6 +443,7 @@ namespace ImGuiScene
                         _textureSrv.NativePointer = pcmd.TextureId;
                         _deviceContext.PixelShader.SetShaderResource(0, _textureSrv);
                         _deviceContext.DrawIndexed((int)pcmd.ElemCount, (int)(pcmd.IdxOffset + indexOffset), (int)(pcmd.VtxOffset + vertexOffset));
+                        _textureSrv.NativePointer = IntPtr.Zero;
                     }
                 }
 


### PR DESCRIPTION
This may resolve a rare crash issue. If not, we can remove it later and just create the ShaderResourceView (at small performance cost) each frame later.