### PR TITLE
fix: Normalize IniPath to UTF-8 for ImGUI

### DIFF
--- a/ImGuiScene/ImGui_Impl/Input/ImGui_Input_Impl_Direct.cs
+++ b/ImGuiScene/ImGui_Impl/Input/ImGui_Input_Impl_Direct.cs
@@ -132,11 +132,12 @@ namespace ImGuiScene
                     Marshal.FreeHGlobal(_iniPathPtr);
                 }
 
-                _iniPathPtr = Marshal.StringToHGlobalAnsi(iniPath);
-                unsafe
-                {
-                    ImGui.GetIO().NativePtr->IniFilename = (byte*)_iniPathPtr.ToPointer();
-                }
+                // ImGUI expects its filenames to be in UTF-8 format, so let's normalize and convert.
+                var utf8Bytes = Encoding.UTF8.GetBytes(iniPath);
+                this._iniPathPtr = Marshal.AllocHGlobal(utf8Bytes.Length + 1);
+                Marshal.Copy(utf8Bytes, 0, this._iniPathPtr, utf8Bytes.Length);
+                
+                ImGui.GetIO().NativePtr->IniFilename = (byte*)this._iniPathPtr.ToPointer();
             }
         }
 


### PR DESCRIPTION
Fixes goatcorp/FFXIVQuickLauncher#1036 by forcing the path to always be UTF-8.

Tested using path `C:\Users\Kaz\AppData\Local\Temp\Cédric\` via fakeboot and confirmed `dalamudUI.ini` was created.